### PR TITLE
Updated coinClass.cs

### DIFF
--- a/Scripts/Game/coinClass.cs
+++ b/Scripts/Game/coinClass.cs
@@ -15,13 +15,6 @@ public class Currency : MonoBehaviour
 	private bool isDragging = false;
 	Vector3 mousePosition;
 
-	// constructor
-	public Currency( string name, double value)
-	{
-		currencyName = name;
-		monetaryValue = value;
-	}
-
 	// Update method
 	private void Update()
 	{


### PR DESCRIPTION
Made merge commit from main.
Added currency constructor to initialize each currency type instead of using Start to fix error: 

Assets\QuickChange\Scripts\Game\ItemClass.cs(23,30): error CS1729: 'Currency' does not contain a constructor that takes 2 arguments

when running Unity.